### PR TITLE
Add wildcard include/exclude filter capabilities (Feature #162).

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ Do not include `.exe` or `.dll` in the names.
 
 Can not be defined with `IncludeAssemblies`.
 
+Can use wildcard patterns such as `*.Tools.*`.
+
 Can take two forms. 
 
 As an element with items delimited by a newline.
@@ -60,12 +62,13 @@ As an element with items delimited by a newline.
         <ExcludeAssemblies>
             Foo
             Bar
+            Company.Tools.*
         </ExcludeAssemblies>
     </LoadAssembliesOnStartup>
     
 Or as a attribute with items delimited by a pipe `|`.
 
-    <LoadAssembliesOnStartup ExcludeAssemblies='Foo|Bar' />
+    <LoadAssembliesOnStartup ExcludeAssemblies='Foo|Bar|Company.Tools.*' />
 
 
 ### IncludeAssemblies
@@ -76,6 +79,8 @@ Do not include `.exe` or `.dll` in the names.
 
 Can not be defined with `ExcludeAssemblies`.
 
+Can use wildcard patterns such as `*.Plugin.Web.*`.
+
 Can take two forms. 
 
 As an element with items delimited by a newline.
@@ -84,12 +89,13 @@ As an element with items delimited by a newline.
         <IncludeAssemblies>
             Foo
             Bar
+            Company.Plugin.*
         </IncludeAssemblies>
     </LoadAssembliesOnStartup>
     
 Or as a attribute with items delimited by a pipe `|`.
 
-    <LoadAssembliesOnStartup IncludeAssemblies='Foo|Bar' />
+    <LoadAssembliesOnStartup IncludeAssemblies='Foo|Bar|Company.Plugin.*' />
 
 
 ### ExcludePrivateAssemblies

--- a/src/LoadAssembliesOnStartup.Fody/Weaving/ReferenceSelector.cs
+++ b/src/LoadAssembliesOnStartup.Fody/Weaving/ReferenceSelector.cs
@@ -11,6 +11,7 @@ namespace LoadAssembliesOnStartup.Fody.Weaving
     using System.Collections.Generic;
     using System.IO;
     using System.Linq;
+    using System.Text.RegularExpressions;
     using System.Xml.Linq;
     using System.Xml.XPath;
     using Mono.Cecil;
@@ -161,7 +162,7 @@ namespace LoadAssembliesOnStartup.Fody.Weaving
 
             if (_configuration.IncludeAssemblies.Any())
             {
-                var contains = _configuration.IncludeAssemblies.Any(x => string.Equals(assemblyNameLowered, x.ToLower()));
+                var contains = _configuration.IncludeAssemblies.Any(x => Regex.IsMatch(assemblyNameLowered, "^" + Regex.Escape(x.ToLower()).Replace("\\*", ".*") + "$"));
                 if (!contains)
                 {
                     FodyEnvironment.WriteInfo($"Ignoring '{assemblyName}' because it is not in the included list");
@@ -172,7 +173,7 @@ namespace LoadAssembliesOnStartup.Fody.Weaving
 
             if (_configuration.ExcludeAssemblies.Any())
             {
-                var contains = _configuration.ExcludeAssemblies.Any(x => string.Equals(assemblyNameLowered, x.ToLower()));
+                var contains = _configuration.ExcludeAssemblies.Any(x => Regex.IsMatch(assemblyNameLowered, "^" + Regex.Escape(x.ToLower()).Replace("\\*", ".*") + "$"));
                 if (contains)
                 {
                     FodyEnvironment.WriteInfo($"Ignoring '{assemblyName}' because it is in the excluded list");


### PR DESCRIPTION
### Description of Change ###
Added a wildcard check to include and exclude checks. This is compatible with strings that contain no wild card which will still perform an exact match.

This was hand-crafted as I could not get the solution to load at all even after 20GB of dependencies got installed it still fails with `The expression "[System.IO.Path]::GetDirectoryName('')" cannot be evaluated.`. The changes are simple enough though to simple do them in notepad.

### Issues Resolved ### 
Feature #162 

### API Changes ###
None

### Platforms Affected ### 
- All

### Behavioral Changes ###
Existing users will experience no changes to their current configuration. The new version will allow wild card patterns as described in include and exclude blocks on top of the normal configuration previously available.

### Testing Procedure ###
Add any wild card pattern and confirm the types are loaded into the app domain at startup.

### PR Checklist ###

- [] I have included examples or tests
- [] I have updated the change log
- [] I am listed in the CONTRIBUTORS file
- [] Rebased on top of the target branch at time of PR
- [X] Changes adhere to coding standard
